### PR TITLE
FIX: config: allowlist WC_* methods

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -92,3 +92,17 @@ enableInlineShortcodes = true
     path = "github.com/wowchemy/wowchemy-hugo-modules/wowchemy-cms"
   [[module.imports]]
     path = "github.com/wowchemy/wowchemy-hugo-modules/wowchemy"
+
+[security]
+  enableInlineShortcodes = true
+
+  [security.exec]
+    allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$']
+    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\w+)$']
+
+  [security.funcs]
+    getenv = ['^HUGO_', '^CI$', "WC_POST_CSS"]
+
+  [security.http]
+    methods = ['(?i)GET|POST']
+    urls = ['.*']


### PR DESCRIPTION
The current configuration settings do not work when using the default
profile for hugo post 0.91. This is because some methods in the
underlying template are deny-listed by default now.

Update the security policy to explicitly allow WC_POST_CSS and allow
hugo builds (at least on 0.111.3 that is!)